### PR TITLE
latest kernel update requires transfer struct to be zeroed

### DIFF
--- a/mcp3008Spi.cpp
+++ b/mcp3008Spi.cpp
@@ -79,6 +79,7 @@ int mcp3008Spi::spiWriteRead( unsigned char *data, int length){
   struct spi_ioc_transfer spi[length];
   int i = 0;
   int retVal = -1; 
+  bzero(spi, sizeof spi); // ioctl scrtuct must be zeroed 
  
 // one spi transfer for each byte
  

--- a/mcp3008Spi.cpp
+++ b/mcp3008Spi.cpp
@@ -79,7 +79,7 @@ int mcp3008Spi::spiWriteRead( unsigned char *data, int length){
   struct spi_ioc_transfer spi[length];
   int i = 0;
   int retVal = -1; 
-  bzero(spi, sizeof spi); // ioctl scrtuct must be zeroed 
+  bzero(spi, sizeof spi); // ioctl struct must be zeroed 
  
 // one spi transfer for each byte
  

--- a/mcp3008Spi.h
+++ b/mcp3008Spi.h
@@ -26,6 +26,7 @@
      
 #include <unistd.h>
 #include <stdint.h>
+#include <string.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <linux/spi/spidev.h>


### PR DESCRIPTION
ioctl msg was returning EINVAL for me originally
